### PR TITLE
Support on external dotenv file and settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ LOG_BASE_NAME="Base name for log files (prod mode)"
 CACHE_DIR="Directory for file-based cache (prod mode)"
 
 ALLOWED_HOSTS="Comma-separated List. e.g.: localhost,127.0.0.1,www.mysite.com"
+
+# Optional if you define .env file in somewhere else
+DOTENV_PATH="Path to dotenv file outside of 'blog_backend' directory"
 ```
 
 ### Database Initialization

--- a/blog_backend/blog_backend/settings.py
+++ b/blog_backend/blog_backend/settings.py
@@ -34,7 +34,9 @@ def get_env_value(name):
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-dotenv.read_dotenv(BASE_DIR / ".env")
+dotenv.read_dotenv(
+    environ["DOTENV_PATH"] if environ.get("DOTENV_PATH", None) else BASE_DIR / ".env"
+)
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/

--- a/blog_backend/blog_backend/wsgi.py
+++ b/blog_backend/blog_backend/wsgi.py
@@ -14,7 +14,11 @@ from django.core.wsgi import get_wsgi_application
 
 import dotenv
 
-dotenv.read_dotenv(Path(__file__).resolve().parent.parent / ".env")
+dotenv.read_dotenv(
+    os.environ["DOTENV_PATH"]
+    if os.environ.get("DOTENV_PATH", None)
+    else Path(__file__).resolve().parent.parent / ".env"
+)
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "blog_backend.settings")
 
 application = get_wsgi_application()

--- a/blog_backend/manage.py
+++ b/blog_backend/manage.py
@@ -7,7 +7,10 @@ import dotenv
 
 
 def main():
-    dotenv.read_dotenv()
+    if os.environ.get("DOTENV_PATH", None):
+        dotenv.read_dotenv(os.environ["DOTENV_PATH"])
+    else:
+        dotenv.read_dotenv()
 
     """Run administrative tasks."""
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "blog_backend.settings")


### PR DESCRIPTION
Not sure if this should be added into current project.

Linux encourages the practice of separating config files under `/etc` from `/opt`. So in the workbook I referenced to, the author moves `settings.py` out from the project directory. Following the same logic, we also need to move `.env` over to `/etc` in our case. As long as `.env` file's readable to the runner, doing so will not create the accessing issue stated in the same document when recompiled.

While it's feasible to do so, that conflicts the `.env`'s original design (placed under the same directory and auto-detected).

To make the initial deployment easier I'll not tackle with this now, and make the decision later on.